### PR TITLE
cnf null fix

### DIFF
--- a/mobius/responder.js
+++ b/mobius/responder.js
@@ -814,7 +814,11 @@ function typeCheckAction(index1, body_Obj) {
                     delete body_Obj[index2];
                 }
                 else {
-                    body_Obj[index2] = parseInt(body_Obj[index2]);
+                    if('cnf' == index2){
+                        body_Obj[index2] = body_Obj[index2];
+                    }else{
+                        body_Obj[index2] = parseInt(body_Obj[index2]);
+                    }
                 }
             }
             else if (index2 == 'aa' || index2 == 'at' || index2 == 'poa' || index2 == 'lbl' || index2 == 'acpi' || index2 == 'srt' || index2 == 'nu' || index2 == 'mid' || index2 == 'macp') {


### PR DESCRIPTION
if index2 attribute is cnf(like 'application/json') that cannot parsed by parseInt
must go to NaN(=null)